### PR TITLE
docs: recommend switching to develop on colab

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,14 @@ STEP3: `pip install -r requirements.txt`
 ### Google Colab quick start
 
 Running the project on [Google Colab](https://colab.research.google.com/) now
-only requires the standard `git clone` step. Once the repository is available in
+only requires the standard `git clone` step. After cloning, switch to the
+`develop` branch:
+
+```bash
+git checkout develop
+```
+
+Once the repository is available in
 your Colab workspace, execute the following cells:
 
 ```python


### PR DESCRIPTION
## Summary
- update the Google Colab quick start instructions to check out the develop branch after cloning

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6409b90e4833397d56a9d01448741