### PR TITLE
Fix Colab dependency pin for mkl-fft

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ kiwisolver==1.4.4
 Markdown==3.4.1
 MarkupSafe==2.1.1
 matplotlib==3.6.0
-mkl-fft==1.3.1
+mkl-fft==1.3.14
 mkl-random==1.2.2
 mkl-service==2.4.0
 networkx==2.8.6


### PR DESCRIPTION
## Summary
- update the pinned mkl-fft dependency to a version that is available on Colab runtimes

## Testing
- not run (dependency-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d65522d6f08333a0fe5b0a90f7210c