### PR TITLE
Resolve numpy dependency conflicts

### DIFF
--- a/requirements-py39.txt
+++ b/requirements-py39.txt
@@ -31,8 +31,6 @@ kiwisolver==1.4.4
 Markdown==3.4.1
 MarkupSafe==2.1.1
 matplotlib==3.6.0
-mkl-fft==1.3.1
-mkl-random==1.2.2
 mkl-service==2.4.0
 networkx==2.8.6
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,11 +24,8 @@ kiwisolver==1.4.4
 Markdown==3.4.1
 MarkupSafe==2.1.1
 matplotlib==3.6.0
-mkl-fft==1.3.1
-mkl-random==1.2.2
-mkl-service==2.4.0
 networkx==2.8.6
-numpy<1.23.0
+numpy==1.22.4
 nvidia-ml-py==11.525.112
 nvitop==1.1.2
 oauthlib==3.2.1


### PR DESCRIPTION
## Summary
- remove Intel MKL helper packages that enforced incompatible numpy versions
- pin numpy to 1.22.4 to align with the rest of the dependency stack

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ecc29c94c88333a536fdbb8142cd57