### PR TITLE
Replace imutils FPS usage with local helper

### DIFF
--- a/Object_Detection/nailfold_classifier/model_inference.py
+++ b/Object_Detection/nailfold_classifier/model_inference.py
@@ -1,9 +1,9 @@
 # coding:utf-8
 import os
+import time
 
 import torch
 import torchvision
-from imutils.video import fps
 from Object_Detection.nailfold_classifier.model_backbone import Backbone
 from torch import nn
 from torchvision.io import read_image
@@ -28,7 +28,42 @@ model.to(device)
 model.eval()
 
 image_path = "./Object_Detection/data/mask_dataset/test/abnormal"
-fps = fps.FPS()
+class SimpleFPS:
+    """Minimal replacement for imutils.video.FPS."""
+
+    def __init__(self):
+        self._start = None
+        self._end = None
+        self._num_frames = 0
+
+    def start(self):
+        self._start = time.perf_counter()
+        self._end = None
+        self._num_frames = 0
+        return self
+
+    def stop(self):
+        if self._start is not None and self._end is None:
+            self._end = time.perf_counter()
+
+    def update(self):
+        if self._start is not None:
+            self._num_frames += 1
+
+    def elapsed(self):
+        if self._start is None:
+            return 0.0
+        end_time = self._end if self._end is not None else time.perf_counter()
+        return end_time - self._start
+
+    def fps(self):
+        elapsed_time = self.elapsed()
+        if elapsed_time == 0:
+            return 0.0
+        return self._num_frames / elapsed_time
+
+
+fps = SimpleFPS()
 fps.start()
 
 with torch.no_grad():

--- a/requirements-py39.txt
+++ b/requirements-py39.txt
@@ -25,7 +25,6 @@ idna==3.4
 imageio==2.22.0
 # Install the backport only where it makes sense (Py<3.10). Python 3.9 is OK.
 importlib-metadata==4.12.0; python_version < "3.10"
-imutils==0.5.4
 joblib==1.2.0
 kiwisolver==1.4.4
 Markdown==3.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 
 albumentations>=1.3
-imutils>=0.5.4
 matplotlib>=3.7
 numpy>=1.23
 onnxruntime>=1.16


### PR DESCRIPTION
## Summary
- replace the imutils FPS helper with a small local implementation used by the nailfold classifier inference script
- remove the imutils requirement so the dependency set installs cleanly on modern Python versions

## Testing
- python -m compileall Object_Detection/nailfold_classifier/model_inference.py

------
https://chatgpt.com/codex/tasks/task_e_68eccdff5e00833389474dfab876d6c4